### PR TITLE
fix(entity/migration): Fix wrong data type

### DIFF
--- a/migrations/1724132372171-generated.ts
+++ b/migrations/1724132372171-generated.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Generated1724132372171 implements MigrationInterface {
+  name = 'Generated1724132372171';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_password_reset" ALTER COLUMN "is_use" SET DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_password_reset" ALTER COLUMN "is_use" SET DEFAULT 'false'`,
+    );
+  }
+}

--- a/src/common/entities/post/user-password-reset.entity.ts
+++ b/src/common/entities/post/user-password-reset.entity.ts
@@ -22,7 +22,7 @@ export class UserPasswordResetEntity {
   @Column({ type: 'timestamptz' })
   expiredAt: Date;
 
-  @Column({ type: 'boolean', default: 'false' })
+  @Column({ type: 'boolean', default: false })
   isUse: boolean;
 
   @ManyToOne(() => UserEntity, (user) => user.userPasswordReset)


### PR DESCRIPTION
This issue cause typeorm generate migration script about is_use column in user_password_reset table every time run generate command

- Fix wrong data type when config default value in column in UserResetPassword Entity
- Generate new migration script for fix this issue

PS. Whoever accept that PR should wash their face then rest (Me! TT)