### PR TITLE
enhance(posts): include user like status in post response

### DIFF
--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -1,5 +1,13 @@
 import { PostEntity } from 'src/common/entities/post/post.entity';
 
-export function combinePostsWithLikes(posts: PostEntity[], likes: number[]) {
-  return posts.map((post, i) => ({ ...post, like: likes[i] }));
+export function combinePostsWithLikes(
+  posts: PostEntity[],
+  likes: number[],
+  isLikes: boolean[],
+) {
+  return posts.map((post, i) => ({
+    ...post,
+    like: likes[i],
+    isLike: isLikes[i],
+  }));
 }

--- a/src/v1/post/like-post.service.ts
+++ b/src/v1/post/like-post.service.ts
@@ -68,4 +68,20 @@ export class PostLikeService {
       post: { id: Equal(post.id) },
     });
   }
+
+  async isUserLikePosts(posts: PostEntity[], userId: string) {
+    const jobs = posts.map((post) => this.isUserLikePost(post.id, userId));
+    return await Promise.all(jobs);
+  }
+
+  async isUserLikePost(postId: string, userId: string) {
+    return !!(await this.postLikeRepo.findOneBy({
+      user: {
+        id: Equal(userId),
+      },
+      post: {
+        id: Equal(postId),
+      },
+    }));
+  }
 }


### PR DESCRIPTION
- Updated `post.controller.ts` to return whether the requesting user has liked each post.
- Improved `post.service.ts` to fetch user-specific like data efficiently.
- Modified `post.ts` utility to combine posts with like counts and user like status.
response look like this
```json
{
    "data": [
        {
            "id": "6e963cae-30d8-4d47-80d2-39ef4e493277",
            "content": "Hi I'm latest post",
            "createdAt": "2024-08-15T05:20:38.093Z",
            "updatedAt": "2024-08-15T05:20:38.093Z",
            "like": 0,
            "isLike": false, // This is new
            "user": {
                "username": "test123456"
            }
        }
    ]
}
```